### PR TITLE
Fix race condition in STTEngineManager engine initialization with thread locks

### DIFF
--- a/test_actual_implementation.py
+++ b/test_actual_implementation.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Test the actual thread-safe implementation with real engine manager"""
+
+import sys
+import os
+import threading
+import time
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from unittest import mock
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(threadName)-10s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# Add project to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Mock all dependencies
+mock_modules = [
+    'numpy', 'scipy', 'scipy.io', 'scipy.io.wavfile',
+    'ffmpeg', 'sanic', 'torch', 'torchaudio', 'omegaconf',
+    'transformers', 'librosa', 'speechbrain', 'nemo_toolkit',
+    'pocketsphinx', 'vosk', 'STT', 'stt', 'whisper'
+]
+
+for module_name in mock_modules:
+    sys.modules[module_name] = mock.MagicMock()
+
+from stts.engine_manager import STTEngineManager
+
+
+class ThreadSafeTestEngine:
+    """Test engine that tracks initialization attempts"""
+    
+    _init_lock = threading.Lock()
+    _init_counts = {}
+    
+    def __init__(self, config):
+        engine_name = self.__class__.__name__
+        
+        # Track initialization
+        with self._init_lock:
+            if engine_name not in self._init_counts:
+                self._init_counts[engine_name] = 0
+            self._init_counts[engine_name] += 1
+            count = self._init_counts[engine_name]
+        
+        # Simulate some initialization work
+        time.sleep(0.05)
+        
+        self.config = config
+        self.name = engine_name
+        self.is_available = True
+        
+        logger.info(f"{engine_name} initialized (attempt #{count}) by {threading.current_thread().name}")
+        
+        if count > 1:
+            logger.error(f"RACE CONDITION: {engine_name} initialized {count} times!")
+    
+    @classmethod
+    def reset_counts(cls):
+        cls._init_counts = {}
+    
+    @classmethod
+    def get_count(cls, name):
+        return cls._init_counts.get(name, 0)
+
+
+def test_lazy_initialization_thread_safety():
+    """Test thread-safe lazy initialization of engines"""
+    
+    logger.info("=" * 60)
+    logger.info("Testing Thread-Safe Lazy Initialization")
+    logger.info("=" * 60)
+    
+    # Create different test engine classes
+    class TestWhisperEngine(ThreadSafeTestEngine):
+        pass
+    
+    class TestVoskEngine(ThreadSafeTestEngine):
+        pass
+    
+    class TestSileroEngine(ThreadSafeTestEngine):
+        pass
+    
+    # Replace engine classes
+    STTEngineManager.ENGINES = {
+        'whisper': TestWhisperEngine,
+        'vosk': TestVoskEngine,
+        'silero': TestSileroEngine
+    }
+    
+    # Reset counts
+    ThreadSafeTestEngine.reset_counts()
+    
+    # Create manager WITHOUT initializing any engines at startup
+    config = {
+        'initialize_all': False,  # Don't initialize anything
+        # Don't provide any engine-specific config to prevent initialization
+    }
+    
+    manager = STTEngineManager(default_engine='whisper', config=config)
+    
+    # Verify thread safety attributes
+    assert hasattr(manager, '_engine_locks'), "Missing _engine_locks"
+    assert hasattr(manager, '_locks_lock'), "Missing _locks_lock"
+    logger.info("✓ Thread safety attributes initialized")
+    
+    # Clear any engines that might have been initialized
+    manager.engines.clear()
+    ThreadSafeTestEngine.reset_counts()
+    
+    # Test: Multiple threads trying to lazily initialize the same engine
+    logger.info("\nTest: 20 concurrent threads requesting uninitialized 'whisper' engine")
+    logger.info("-" * 40)
+    
+    def request_engine(engine_name, thread_id):
+        thread_name = f"T-{thread_id:02d}"
+        threading.current_thread().name = thread_name
+        
+        try:
+            logger.debug(f"{thread_name} requesting {engine_name}")
+            engine = manager.get_engine(engine_name)
+            logger.debug(f"{thread_name} got {engine_name}")
+            return True
+        except Exception as e:
+            logger.error(f"{thread_name} failed: {e}")
+            return False
+    
+    # Launch threads
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        futures = [
+            executor.submit(request_engine, 'whisper', i)
+            for i in range(20)
+        ]
+        
+        results = [f.result() for f in as_completed(futures)]
+    
+    # Check initialization count
+    whisper_count = ThreadSafeTestEngine.get_count('TestWhisperEngine')
+    logger.info(f"\nWhisper initialization count: {whisper_count}")
+    
+    if whisper_count == 1:
+        logger.info("✓ PASS: Whisper initialized exactly once with 20 concurrent requests")
+    else:
+        logger.error(f"✗ FAIL: Race condition detected! Whisper initialized {whisper_count} times")
+        return False
+    
+    # Verify lock was created
+    if 'whisper' in manager._engine_locks:
+        logger.info("✓ Lock created for 'whisper' during lazy initialization")
+    else:
+        logger.error("✗ No lock found for 'whisper'")
+        return False
+    
+    # Test multiple different engines concurrently
+    logger.info("\nTest: Concurrent initialization of multiple engines")
+    logger.info("-" * 40)
+    
+    # Reset for next test
+    manager.engines.clear()
+    manager._engine_locks.clear()
+    ThreadSafeTestEngine.reset_counts()
+    
+    with ThreadPoolExecutor(max_workers=30) as executor:
+        futures = []
+        # 10 threads each for 3 different engines
+        for engine in ['whisper', 'vosk', 'silero']:
+            for i in range(10):
+                futures.append(
+                    executor.submit(request_engine, engine, i + 100)
+                )
+        
+        results = [f.result() for f in as_completed(futures)]
+    
+    # Check all initialization counts
+    logger.info("\nInitialization counts:")
+    all_good = True
+    for engine_class, engine_name in [
+        ('TestWhisperEngine', 'whisper'),
+        ('TestVoskEngine', 'vosk'), 
+        ('TestSileroEngine', 'silero')
+    ]:
+        count = ThreadSafeTestEngine.get_count(engine_class)
+        if count == 1:
+            logger.info(f"  {engine_name}: {count} ✓")
+        else:
+            logger.error(f"  {engine_name}: {count} ✗ (expected 1)")
+            all_good = False
+    
+    if not all_good:
+        logger.error("\n✗ FAIL: Race conditions detected")
+        return False
+    
+    logger.info("\n✓ PASS: All engines initialized exactly once")
+    
+    # Verify locks were created for all engines
+    for engine in ['whisper', 'vosk', 'silero']:
+        if engine not in manager._engine_locks:
+            logger.error(f"✗ No lock for {engine}")
+            return False
+    
+    logger.info("✓ All engine locks properly created")
+    
+    logger.info("\n" + "=" * 60)
+    logger.info("SUCCESS: Thread-safe lazy initialization working correctly!")
+    logger.info("No race conditions detected.")
+    logger.info("=" * 60)
+    
+    return True
+
+
+if __name__ == "__main__":
+    success = test_lazy_initialization_thread_safety()
+    sys.exit(0 if success else 1)

--- a/test_engine_manager_thread_safety.py
+++ b/test_engine_manager_thread_safety.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Test thread safety of the actual engine_manager implementation"""
+
+import sys
+import os
+import threading
+import time
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from unittest import mock
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(threadName)-10s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# Add project to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Mock all dependencies before importing
+mock_modules = [
+    'numpy', 'scipy', 'scipy.io', 'scipy.io.wavfile',
+    'ffmpeg', 'sanic', 'torch', 'torchaudio', 'omegaconf',
+    'transformers', 'librosa', 'speechbrain', 'nemo_toolkit',
+    'pocketsphinx', 'vosk', 'STT', 'stt', 'whisper'
+]
+
+for module_name in mock_modules:
+    sys.modules[module_name] = mock.MagicMock()
+
+# Now import our module
+from stts.engine_manager import STTEngineManager
+
+
+class MockSTTEngine:
+    """Mock STT Engine that simulates initialization delay"""
+    
+    initialization_count = {}
+    initialization_lock = threading.Lock()
+    
+    def __init__(self, config):
+        # Track initialization attempts
+        engine_name = config.get('name', 'unknown')
+        with self.initialization_lock:
+            if engine_name not in self.initialization_count:
+                self.initialization_count[engine_name] = 0
+            self.initialization_count[engine_name] += 1
+            count = self.initialization_count[engine_name]
+        
+        # Simulate initialization delay
+        time.sleep(0.05)
+        
+        self.config = config
+        self.name = engine_name
+        self.is_available = True
+        
+        logger.info(f"MockSTTEngine '{engine_name}' initialized (attempt #{count}) by {threading.current_thread().name}")
+        
+        if count > 1:
+            logger.warning(f"WARNING: Duplicate initialization of {engine_name}!")
+
+
+def test_thread_safe_initialization():
+    """Test that the engine manager properly handles concurrent initialization requests"""
+    
+    logger.info("=" * 60)
+    logger.info("Testing Thread-Safe Engine Manager")
+    logger.info("=" * 60)
+    
+    # Replace all engine classes with our mock
+    for engine_name in STTEngineManager.ENGINES:
+        STTEngineManager.ENGINES[engine_name] = MockSTTEngine
+    
+    # Reset initialization counter
+    MockSTTEngine.initialization_count = {}
+    
+    # Create manager with no pre-initialization
+    config = {
+        'initialize_all': False,
+        'whisper': {'name': 'whisper'},
+        'vosk': {'name': 'vosk'},
+        'silero': {'name': 'silero'}
+    }
+    
+    manager = STTEngineManager(default_engine='whisper', config=config)
+    
+    # Verify thread safety attributes exist
+    assert hasattr(manager, '_engine_locks'), "Missing _engine_locks attribute"
+    assert hasattr(manager, '_locks_lock'), "Missing _locks_lock attribute"
+    assert isinstance(manager._locks_lock, type(threading.Lock())), "_locks_lock should be a Lock"
+    
+    logger.info("✓ Thread safety attributes properly initialized")
+    
+    # Test concurrent access to the same engine
+    logger.info("\nTest 1: Concurrent access to same engine")
+    logger.info("-" * 40)
+    
+    results = []
+    errors = []
+    
+    def get_engine_worker(engine_name, worker_id):
+        thread_name = f"Worker-{worker_id:02d}"
+        threading.current_thread().name = thread_name
+        
+        try:
+            logger.debug(f"{thread_name} requesting {engine_name}")
+            engine = manager.get_engine(engine_name)
+            logger.debug(f"{thread_name} got {engine_name}")
+            return f"Success: {thread_name}"
+        except Exception as e:
+            logger.error(f"{thread_name} failed: {e}")
+            return f"Error: {thread_name} - {e}"
+    
+    # Launch 20 threads all trying to get 'whisper' engine
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        futures = [
+            executor.submit(get_engine_worker, 'whisper', i)
+            for i in range(20)
+        ]
+        
+        for future in as_completed(futures):
+            result = future.result()
+            if result.startswith("Success"):
+                results.append(result)
+            else:
+                errors.append(result)
+    
+    # Check initialization count
+    whisper_count = MockSTTEngine.initialization_count.get('whisper', 0)
+    logger.info(f"\nWhisper initialization count: {whisper_count}")
+    
+    if whisper_count == 1:
+        logger.info("✓ PASS: Whisper initialized exactly once")
+    else:
+        logger.error(f"✗ FAIL: Whisper initialized {whisper_count} times (expected 1)")
+        return False
+    
+    # Test 2: Multiple engines with concurrent requests
+    logger.info("\nTest 2: Multiple engines with concurrent requests")
+    logger.info("-" * 40)
+    
+    with ThreadPoolExecutor(max_workers=30) as executor:
+        futures = []
+        # 10 threads each for whisper (already initialized), vosk, and silero
+        for engine in ['whisper', 'vosk', 'silero']:
+            for i in range(10):
+                futures.append(
+                    executor.submit(get_engine_worker, engine, i + 100)
+                )
+        
+        for future in as_completed(futures):
+            result = future.result()
+    
+    # Check initialization counts
+    logger.info("\nFinal initialization counts:")
+    all_correct = True
+    for engine in ['whisper', 'vosk', 'silero']:
+        count = MockSTTEngine.initialization_count.get(engine, 0)
+        expected = 1
+        status = "✓" if count == expected else "✗"
+        logger.info(f"  {engine}: {count} {status}")
+        if count != expected:
+            all_correct = False
+    
+    if not all_correct:
+        logger.error("\n✗ FAIL: Some engines were initialized multiple times")
+        return False
+    
+    logger.info("\n✓ PASS: All engines initialized exactly once")
+    
+    # Test 3: Check that locks are created per engine
+    logger.info("\nTest 3: Verify per-engine locks")
+    logger.info("-" * 40)
+    
+    # After initialization, we should have locks for each accessed engine
+    if 'whisper' in manager._engine_locks:
+        logger.info("✓ Lock created for 'whisper'")
+    else:
+        logger.error("✗ No lock for 'whisper'")
+        return False
+    
+    if 'vosk' in manager._engine_locks:
+        logger.info("✓ Lock created for 'vosk'")
+    else:
+        logger.error("✗ No lock for 'vosk'")
+        return False
+    
+    if 'silero' in manager._engine_locks:
+        logger.info("✓ Lock created for 'silero'")
+    else:
+        logger.error("✗ No lock for 'silero'")
+        return False
+    
+    # Verify all locks are actual Lock objects
+    for engine_name, lock in manager._engine_locks.items():
+        if not isinstance(lock, type(threading.Lock())):
+            logger.error(f"✗ {engine_name} lock is not a threading.Lock")
+            return False
+    
+    logger.info("✓ All engine locks are proper threading.Lock objects")
+    
+    logger.info("\n" + "=" * 60)
+    logger.info("SUCCESS: All thread safety tests PASSED!")
+    logger.info("The engine manager is properly thread-safe.")
+    logger.info("=" * 60)
+    
+    return True
+
+
+if __name__ == "__main__":
+    success = test_thread_safe_initialization()
+    sys.exit(0 if success else 1)

--- a/test_thread_safety.py
+++ b/test_thread_safety.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Test thread-safe engine initialization in STTEngineManager"""
+
+import threading
+import time
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Dict, Any
+import sys
+import os
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from stts.engine_manager import STTEngineManager
+
+# Configure logging to see detailed initialization messages
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(threadName)-10s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class InitializationTracker:
+    """Track engine initialization attempts and results"""
+    
+    def __init__(self):
+        self.attempts: Dict[str, List[str]] = {}
+        self.successes: Dict[str, List[str]] = {}
+        self.lock = threading.Lock()
+    
+    def record_attempt(self, engine_name: str, thread_name: str):
+        with self.lock:
+            if engine_name not in self.attempts:
+                self.attempts[engine_name] = []
+            self.attempts[engine_name].append(thread_name)
+    
+    def record_success(self, engine_name: str, thread_name: str):
+        with self.lock:
+            if engine_name not in self.successes:
+                self.successes[engine_name] = []
+            self.successes[engine_name].append(thread_name)
+    
+    def get_stats(self) -> Dict[str, Any]:
+        with self.lock:
+            return {
+                'attempts': dict(self.attempts),
+                'successes': dict(self.successes),
+                'duplicate_attempts': {
+                    engine: len(threads) > 1 
+                    for engine, threads in self.attempts.items()
+                }
+            }
+
+
+def test_concurrent_initialization():
+    """Test that multiple threads trying to initialize the same engine don't cause issues"""
+    
+    logger.info("=" * 80)
+    logger.info("Testing concurrent engine initialization")
+    logger.info("=" * 80)
+    
+    # Create manager with no pre-initialized engines
+    config = {
+        'initialize_all': False,  # Don't initialize any engines at startup
+        'whisper': {'model_size': 'tiny'},
+        'vosk': {},
+        'silero': {}
+    }
+    
+    manager = STTEngineManager(default_engine='whisper', config=config)
+    tracker = InitializationTracker()
+    
+    def get_engine_concurrent(engine_name: str, thread_id: int) -> str:
+        """Worker function to get an engine"""
+        thread_name = f"Worker-{thread_id}"
+        threading.current_thread().name = thread_name
+        
+        try:
+            tracker.record_attempt(engine_name, thread_name)
+            logger.info(f"Thread {thread_name} requesting {engine_name} engine")
+            
+            # Small random delay to increase chance of race condition
+            time.sleep(0.001 * (thread_id % 3))
+            
+            engine = manager.get_engine(engine_name)
+            tracker.record_success(engine_name, thread_name)
+            
+            logger.info(f"Thread {thread_name} successfully got {engine_name} engine")
+            return f"Success: {thread_name} got {engine_name}"
+            
+        except Exception as e:
+            logger.error(f"Thread {thread_name} failed to get {engine_name}: {e}")
+            return f"Failed: {thread_name} - {str(e)}"
+    
+    # Test 1: Multiple threads requesting the same engine simultaneously
+    logger.info("\nTest 1: Multiple threads requesting same engine")
+    logger.info("-" * 40)
+    
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        # Submit 10 workers all trying to get 'whisper' engine
+        futures = [
+            executor.submit(get_engine_concurrent, 'whisper', i)
+            for i in range(10)
+        ]
+        
+        results = []
+        for future in as_completed(futures):
+            result = future.result()
+            results.append(result)
+            logger.debug(f"Result: {result}")
+    
+    # Check that engine was only initialized once
+    stats = tracker.get_stats()
+    logger.info(f"\nStats for 'whisper' engine:")
+    logger.info(f"  Total attempts: {len(stats['attempts'].get('whisper', []))}")
+    logger.info(f"  Successful: {len(stats['successes'].get('whisper', []))}")
+    
+    # Verify engine is actually initialized
+    assert 'whisper' in manager.list_available_engines(), "Whisper engine should be initialized"
+    
+    # Test 2: Multiple threads requesting different engines
+    logger.info("\n" + "=" * 80)
+    logger.info("Test 2: Multiple threads requesting different engines")
+    logger.info("-" * 40)
+    
+    # Reset tracker for second test
+    tracker = InitializationTracker()
+    
+    with ThreadPoolExecutor(max_workers=9) as executor:
+        futures = []
+        # 3 threads each for whisper (already initialized), vosk, and silero
+        for i in range(3):
+            futures.append(executor.submit(get_engine_concurrent, 'whisper', i))
+            futures.append(executor.submit(get_engine_concurrent, 'vosk', i + 3))
+            futures.append(executor.submit(get_engine_concurrent, 'silero', i + 6))
+        
+        results = []
+        for future in as_completed(futures):
+            result = future.result()
+            results.append(result)
+    
+    stats = tracker.get_stats()
+    for engine in ['whisper', 'vosk', 'silero']:
+        logger.info(f"\nStats for '{engine}' engine:")
+        logger.info(f"  Total attempts: {len(stats['attempts'].get(engine, []))}")
+        logger.info(f"  Successful: {len(stats['successes'].get(engine, []))}")
+    
+    # Test 3: Stress test with many threads
+    logger.info("\n" + "=" * 80)
+    logger.info("Test 3: Stress test with many concurrent requests")
+    logger.info("-" * 40)
+    
+    stress_engines = ['whisper', 'vosk', 'silero']
+    num_threads_per_engine = 20
+    
+    with ThreadPoolExecutor(max_workers=60) as executor:
+        futures = []
+        for engine in stress_engines:
+            for i in range(num_threads_per_engine):
+                futures.append(executor.submit(get_engine_concurrent, engine, i))
+        
+        success_count = 0
+        failure_count = 0
+        for future in as_completed(futures):
+            result = future.result()
+            if result.startswith("Success"):
+                success_count += 1
+            else:
+                failure_count += 1
+    
+    logger.info(f"\nStress test results:")
+    logger.info(f"  Total requests: {len(futures)}")
+    logger.info(f"  Successful: {success_count}")
+    logger.info(f"  Failed: {failure_count}")
+    
+    # Verify final state
+    available = manager.list_available_engines()
+    logger.info(f"\nFinal available engines: {available}")
+    
+    # Test 4: Verify no duplicate models in memory
+    logger.info("\n" + "=" * 80)
+    logger.info("Test 4: Verify no duplicate engine instances")
+    logger.info("-" * 40)
+    
+    # Check that each engine appears exactly once in the manager
+    engine_ids = {}
+    for name, engine in manager.engines.items():
+        engine_id = id(engine)
+        if engine_id in engine_ids:
+            logger.error(f"DUPLICATE: Engine {name} has same ID as {engine_ids[engine_id]}")
+            assert False, "Duplicate engine instance detected!"
+        engine_ids[engine_id] = name
+    
+    logger.info(f"✓ All {len(engine_ids)} engines have unique instances")
+    
+    logger.info("\n" + "=" * 80)
+    logger.info("All thread safety tests passed!")
+    logger.info("=" * 80)
+
+
+def test_initialization_performance():
+    """Compare performance with and without proper locking"""
+    
+    logger.info("\n" + "=" * 80)
+    logger.info("Testing initialization performance")
+    logger.info("=" * 80)
+    
+    config = {
+        'initialize_all': False,
+        'whisper': {'model_size': 'tiny'}
+    }
+    
+    # Test with single thread (baseline)
+    manager = STTEngineManager(default_engine='whisper', config=config)
+    
+    start_time = time.time()
+    engine = manager.get_engine('whisper')
+    single_thread_time = time.time() - start_time
+    
+    logger.info(f"Single thread initialization time: {single_thread_time:.4f} seconds")
+    
+    # Test with multiple threads (should not significantly impact performance)
+    manager2 = STTEngineManager(default_engine='vosk', config={'vosk': {}})
+    
+    def timed_get(name: str) -> float:
+        start = time.time()
+        manager2.get_engine(name)
+        return time.time() - start
+    
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(timed_get, 'vosk') for _ in range(10)]
+        times = [f.result() for f in as_completed(futures)]
+    
+    avg_time = sum(times) / len(times)
+    logger.info(f"Average time with 10 concurrent threads: {avg_time:.4f} seconds")
+    logger.info(f"Max time: {max(times):.4f} seconds")
+    logger.info(f"Min time: {min(times):.4f} seconds")
+    
+    # The first thread should take the most time (actual initialization)
+    # Other threads should be fast (just waiting on lock)
+    logger.info("\n✓ Performance test completed")
+
+
+if __name__ == "__main__":
+    try:
+        test_concurrent_initialization()
+        test_initialization_performance()
+        
+        logger.info("\n" + "=" * 80)
+        logger.info("ALL TESTS PASSED SUCCESSFULLY!")
+        logger.info("Thread-safe engine initialization is working correctly.")
+        logger.info("=" * 80)
+        
+    except Exception as e:
+        logger.error(f"Test failed: {e}", exc_info=True)
+        sys.exit(1)

--- a/test_thread_safety_simple.py
+++ b/test_thread_safety_simple.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Simplified test for thread-safe engine initialization"""
+
+import threading
+import time
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, Any
+import sys
+import os
+
+# Configure logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(threadName)-10s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class MockEngine:
+    """Mock STT Engine for testing purposes"""
+    
+    def __init__(self, config: Dict[str, Any]):
+        self.config = config
+        self.name = config.get('name', 'mock')
+        self.is_available = True
+        # Simulate initialization delay
+        time.sleep(0.1)
+        logger.info(f"MockEngine {self.name} initialized by {threading.current_thread().name}")
+
+
+class SimplifiedEngineManager:
+    """Simplified version of STTEngineManager for testing thread safety"""
+    
+    ENGINES = {
+        'engine1': MockEngine,
+        'engine2': MockEngine,
+        'engine3': MockEngine,
+    }
+    
+    def __init__(self):
+        self.engines: Dict[str, MockEngine] = {}
+        self._engine_locks: Dict[str, threading.Lock] = {}
+        self._locks_lock = threading.Lock()
+        self.initialization_count = {}  # Track how many times each engine is initialized
+        self._count_lock = threading.Lock()
+    
+    def get_engine(self, name: str) -> MockEngine:
+        """Get an engine with thread-safe initialization"""
+        
+        # Double-checked locking pattern
+        if name not in self.engines:
+            # Get or create lock for this specific engine
+            with self._locks_lock:
+                if name not in self._engine_locks:
+                    self._engine_locks[name] = threading.Lock()
+                engine_lock = self._engine_locks[name]
+            
+            # Try to initialize with proper locking
+            with engine_lock:
+                # Double-check after acquiring lock
+                if name not in self.engines:
+                    logger.info(f"Thread {threading.current_thread().name}: Initializing {name}")
+                    
+                    # Track initialization count
+                    with self._count_lock:
+                        if name not in self.initialization_count:
+                            self.initialization_count[name] = 0
+                        self.initialization_count[name] += 1
+                    
+                    # Create the engine
+                    if name in self.ENGINES:
+                        engine = self.ENGINES[name]({'name': name})
+                        self.engines[name] = engine
+                        logger.info(f"Thread {threading.current_thread().name}: Successfully initialized {name}")
+                    else:
+                        raise ValueError(f"Unknown engine: {name}")
+                else:
+                    logger.debug(f"Thread {threading.current_thread().name}: {name} already initialized")
+        
+        return self.engines[name]
+
+
+def test_thread_safety():
+    """Test that multiple threads don't cause duplicate initialization"""
+    
+    logger.info("=" * 60)
+    logger.info("Testing Thread-Safe Engine Initialization")
+    logger.info("=" * 60)
+    
+    manager = SimplifiedEngineManager()
+    results = {'success': 0, 'errors': 0}
+    results_lock = threading.Lock()
+    
+    def get_engine_worker(engine_name: str, worker_id: int):
+        """Worker function to get an engine"""
+        thread_name = f"Worker-{worker_id:02d}"
+        threading.current_thread().name = thread_name
+        
+        try:
+            logger.debug(f"{thread_name} requesting {engine_name}")
+            engine = manager.get_engine(engine_name)
+            logger.debug(f"{thread_name} got {engine_name}")
+            
+            with results_lock:
+                results['success'] += 1
+            return True
+            
+        except Exception as e:
+            logger.error(f"{thread_name} failed: {e}")
+            with results_lock:
+                results['errors'] += 1
+            return False
+    
+    # Test 1: Many threads requesting the same engine
+    logger.info("\nTest 1: 20 threads requesting the same engine")
+    logger.info("-" * 40)
+    
+    with ThreadPoolExecutor(max_workers=20) as executor:
+        futures = [
+            executor.submit(get_engine_worker, 'engine1', i)
+            for i in range(20)
+        ]
+        
+        for future in as_completed(futures):
+            future.result()
+    
+    # Check that engine was initialized exactly once
+    init_count = manager.initialization_count.get('engine1', 0)
+    logger.info(f"\nEngine1 initialization count: {init_count}")
+    
+    if init_count == 1:
+        logger.info("✓ PASS: Engine initialized exactly once despite 20 concurrent requests")
+    else:
+        logger.error(f"✗ FAIL: Engine initialized {init_count} times (expected 1)")
+        return False
+    
+    # Test 2: Multiple engines with concurrent requests
+    logger.info("\nTest 2: Multiple engines with concurrent requests")
+    logger.info("-" * 40)
+    
+    manager2 = SimplifiedEngineManager()
+    
+    def get_engine_worker2(engine_name: str, worker_id: int):
+        """Worker function for manager2"""
+        thread_name = f"Worker-{worker_id:02d}"
+        threading.current_thread().name = thread_name
+        
+        try:
+            logger.debug(f"{thread_name} requesting {engine_name}")
+            engine = manager2.get_engine(engine_name)  # Use manager2 here
+            logger.debug(f"{thread_name} got {engine_name}")
+            
+            with results_lock:
+                results['success'] += 1
+            return True
+            
+        except Exception as e:
+            logger.error(f"{thread_name} failed: {e}")
+            with results_lock:
+                results['errors'] += 1
+            return False
+    
+    with ThreadPoolExecutor(max_workers=30) as executor:
+        futures = []
+        # 10 threads for each of 3 engines
+        for engine_num in range(1, 4):
+            for worker_id in range(10):
+                futures.append(
+                    executor.submit(get_engine_worker2, f'engine{engine_num}', worker_id + engine_num*10)
+                )
+        
+        for future in as_completed(futures):
+            future.result()
+    
+    # Check initialization counts
+    logger.info("\nInitialization counts:")
+    all_correct = True
+    for engine_name in ['engine1', 'engine2', 'engine3']:
+        count = manager2.initialization_count.get(engine_name, 0)
+        logger.info(f"  {engine_name}: {count}")
+        if count != 1:
+            all_correct = False
+            logger.error(f"    ✗ Expected 1, got {count}")
+        else:
+            logger.info(f"    ✓ Correct")
+    
+    if all_correct:
+        logger.info("\n✓ PASS: All engines initialized exactly once")
+    else:
+        logger.error("\n✗ FAIL: Some engines initialized multiple times")
+        return False
+    
+    # Test 3: Verify engine instances are unique
+    logger.info("\nTest 3: Verify unique engine instances")
+    logger.info("-" * 40)
+    
+    engine_ids = set()
+    for name, engine in manager2.engines.items():
+        engine_id = id(engine)
+        if engine_id in engine_ids:
+            logger.error(f"✗ FAIL: Duplicate engine instance found for {name}")
+            return False
+        engine_ids.add(engine_id)
+    
+    logger.info(f"✓ PASS: All {len(engine_ids)} engine instances are unique")
+    
+    # Summary
+    logger.info("\n" + "=" * 60)
+    logger.info("SUMMARY: All thread safety tests PASSED!")
+    logger.info("The double-checked locking pattern is working correctly.")
+    logger.info("=" * 60)
+    
+    return True
+
+
+if __name__ == "__main__":
+    success = test_thread_safety()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
- Introduces thread-safe lazy initialization for STTEngineManager engines
- Uses per-engine locks with double-checked locking pattern to prevent race conditions
- Adds a lock to manage the dictionary of engine locks
- Improves logging to trace thread activity during engine initialization

## Changes

### Core Engine Manager
- Added `_engine_locks` dictionary and `_locks_lock` to STTEngineManager for thread-safe lock management
- Modified `get_engine` method to:
  - Acquire a lock specific to the requested engine
  - Use double-checked locking to ensure only one initialization per engine
  - Log thread names and initialization attempts for better traceability
  - Raise appropriate errors if engine is unavailable or unknown

### Tests
- Added comprehensive multi-threaded tests to verify thread safety and race condition prevention:
  - `test_actual_implementation.py`: Real engine manager with mock engines, testing concurrent initialization
  - `test_engine_manager_thread_safety.py`: Mock engine with initialization delay to detect duplicate initializations
  - `test_thread_safety.py`: Detailed tests with logging and concurrency for multiple engines
  - `test_thread_safety_simple.py`: Simplified test for thread-safe initialization using a mock manager

## Test plan
- Run all new test scripts to ensure no race conditions occur during concurrent engine initialization
- Verify that each engine is initialized exactly once even under high concurrency
- Confirm that locks are created per engine and used correctly
- Check logs for expected thread-safe initialization messages
- Validate that no duplicate engine instances exist after concurrent access

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/a219eabb-2121-4f99-95ed-5310f616407f